### PR TITLE
Remove scout scaffold from Codex repo and document external scout repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A minimal web application that polls the Virta Global charging station API and n
 
 The app is built with Node.js, Express, and a small client-side script. It is suitable for hosting on free Node-friendly platforms such as [Render](https://render.com/) or [Fly.io](https://fly.io/).
 
+## Scout Skills Repo
+
+The `scout` project is maintained as a separate local git repository at `/workspace/scout` with its skills stored under `.agent/skills`.
+
 ## Features
 
 - Server-side proxy for the Virta Global station endpoint to avoid CORS issues.


### PR DESCRIPTION
### Motivation
- The `scout` scaffold should be maintained as a separate repository rather than residing inside the Codex repo to keep responsibilities separated.
- Ensure developers can find the external `scout` repository and know where skills live (`.agent/skills`).

### Description
- Remove scaffold files from the Codex repository: `scout/README.md`, `scout/.agent/README.md`, and `scout/.agent/skills/.gitkeep` were deleted from `/workspace/Codex`.
- Initialize a new git repository at `/workspace/scout` and add the scaffold files `README.md`, `.agent/README.md`, and `.agent/skills/.gitkeep` there.
- Commit the new `scout` repo with message `Initial scout scaffold` and remove the scaffold from Codex with commit message `Remove scout scaffold from Codex repo`.
- Update `/workspace/Codex/README.md` to document that the `scout` project lives as a separate local repo at `/workspace/scout` and that skills are stored under `.agent/skills`.

### Testing
- No automated tests were run for these repository and documentation updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c08378dc8325886ae24957c80bbb)